### PR TITLE
let clang 6.0.1 compile

### DIFF
--- a/src/base/factorization/bigint/sf_mpqs.cc
+++ b/src/base/factorization/bigint/sf_mpqs.cc
@@ -507,7 +507,7 @@ namespace LiDIA {
                   }
                 }
                       
-                if(faktor[0] == (char) NULL) {
+                if(faktor[0] == (char)(size_t) NULL) {
                   continue;
                 }
               }

--- a/src/base/simple_classes/factorization/mpqs.cc
+++ b/src/base/simple_classes/factorization/mpqs.cc
@@ -515,7 +515,7 @@ static void zusam (unsigned int size_exp, int * FB, const bigint & kN)
 			    }
 			}
 		      
-		      if (faktor[0] == (char) NULL)
+		      if (faktor[0] == (char)(size_t) NULL)
 			continue;
 		    }
 		  

--- a/src/finite_fields/gf2n/gf2nin.cc
+++ b/src/finite_fields/gf2n/gf2nin.cc
@@ -80,7 +80,7 @@ std::istream & operator >> (std::istream & in_strm, gf2n & a)
 	}
 	else {
 		str = line+i+1;
-		line[i] = (char) NULL;
+		line[i] = (char)(size_t) NULL;
 
 		if (strcmp(line, "HEX") == 0) {
 			hexin(a, str);


### PR DESCRIPTION
this fixes errors such as the one discussed [here](https://stackoverflow.com/questions/22419063/error-cast-from-pointer-to-smaller-type-int-loses-information-in-eaglview-mm) - cast from pointer to smaller type FOO loses information